### PR TITLE
fix run-path-missing-package.js on TaskCluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -64,4 +64,4 @@ tasks:
           node ./bin/postinstall.js &&
           (Xvfb :2 -screen 0 1024x768x24 &) &&
           export DISPLAY=:2 &&
-          npm test
+          TMPDIR=/tmp npm test

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -57,6 +57,7 @@ tasks:
         - >-
           apt-get update -y &&
           apt-get install -y libgtk-3-0 libdbus-glib-1-2 xvfb &&
+          su node -c 'cd &&
           git clone {{event.head.repo.url}} repo &&
           cd repo &&
           git checkout {{event.head.sha}} &&
@@ -64,4 +65,4 @@ tasks:
           node ./bin/postinstall.js &&
           (Xvfb :2 -screen 0 1024x768x24 &) &&
           export DISPLAY=:2 &&
-          TMPDIR=/tmp npm test
+          npm test'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "bin": "./bin/cli.js",
   "scripts": {
     "postinstall": "node ./bin/postinstall.js",
+    "start": "node ./bin/cli.js",
     "test": "eslint --ext .js,.jsm . && tap test/*.js --cov --timeout=600"
   },
   "dependencies": {

--- a/test/run-path-missing-package.js
+++ b/test/run-path-missing-package.js
@@ -27,6 +27,7 @@ const tap = require('tap');
 
 let exitCode = 0;
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qbrt-test-'));
+console.log(`tempDir: ${tempDir}`);
 
 new Promise((resolve, reject) => {
   // Copy the app to a temporary directory to avoid qbrt finding
@@ -42,9 +43,9 @@ new Promise((resolve, reject) => {
   let totalOutput = '';
 
   child.stdout.on('data', data => {
-    const output = data.toString('utf8').trim();
-    console.log(output);
+    const output = data.toString('utf8');
     totalOutput += output;
+    console.log(output.trim());
   });
 
   child.stderr.on('data', data => {
@@ -52,7 +53,7 @@ new Promise((resolve, reject) => {
   });
 
   child.on('close', code => {
-    tap.equal(totalOutput, 'console.log: Hello, World!');
+    tap.equal(totalOutput.trim(), 'console.log: Hello, World!');
     tap.equal(code, 0, 'app exited with success code');
   });
 

--- a/test/run-path-missing-package.js
+++ b/test/run-path-missing-package.js
@@ -27,7 +27,6 @@ const tap = require('tap');
 
 let exitCode = 0;
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qbrt-test-'));
-console.log(`tempDir: ${tempDir}`);
 
 new Promise((resolve, reject) => {
   // Copy the app to a temporary directory to avoid qbrt finding


### PR DESCRIPTION
@cvan This fixes run-path-missing-package.js on TaskCluster. See https://github.com/mykmelez/qbrt/commit/b32bfc7995cc40d32d440cf5d4d99f11de1d0fbd for an explanation of the problem.