### PR TITLE
fix repeated toggling of DevTools window and force reload

### DIFF
--- a/modules/Runtime.jsm
+++ b/modules/Runtime.jsm
@@ -146,7 +146,7 @@ this.Runtime = {
   },
 
   toggleDevTools(target) {
-    if (global.devToolsActive.has(target)) {
+    if (global.devToolsOpened.has(target)) {
       return this.closeDevTools(target);
     }
 

--- a/shell/shell.js
+++ b/shell/shell.js
@@ -87,13 +87,9 @@ const UI = {
 
     const onToolsKeydown = event => {
       dump('onToolsKeydown\n');
+      // NB: the DevTools window handles its own reload key events,
+      // so we don't need to handle them ourselves.
       // TODO: make this DRY, so we're not repeating ourselves below.
-      if (shortcuts.hardReloadPage(event)) {
-        browser.reload(true);
-      }
-      if (shortcuts.reloadPage(event)) {
-        browser.reload();
-      }
       if (shortcuts.toggleDevTools(event)) {
         dump('onToolsKeydown [shortcut OK]\n');
         Runtime.toggleDevTools(browser);
@@ -103,12 +99,15 @@ const UI = {
     const onToolsUnload = () => {
       dump('onToolsUnload\n');
       toolsWindow.removeEventListener('keydown', onToolsKeydown);
+      // Nullify our persistent reference to the current tools window,
+      // so toggling a second DevTools window will close it.
+      toolsWindow = null;
     };
 
     const onToolsLoad = () => {
       dump('onToolsLoad\n');
       toolsWindow.addEventListener('keydown', onToolsKeydown);
-      toolsWindow.removeEventListener('unload', onToolsUnload);
+      toolsWindow.addEventListener('unload', onToolsUnload);
     };
 
     browser.addEventListener('keydown', event => {

--- a/shell/shell.js
+++ b/shell/shell.js
@@ -113,7 +113,7 @@ const UI = {
     browser.addEventListener('keydown', event => {
       // Hard-reload the web page when the `Shift + F5` keys (or `Command + Shift + R` on Mac) are pressed.
       if (shortcuts.hardReloadPage(event)) {
-        browser.reload(true);
+        browser.webNavigation.reload(Ci.nsIWebNavigation.LOAD_FLAGS_BYPASS_CACHE);
         return;
       }
 


### PR DESCRIPTION
This includes a few fixes to ensure that repeatedly toggling the DevTools window with its keyboard shortcut works. Without these fixes, I found that I could open a DevTools window, close it again, and open a new one; but then I couldn't close the new one.

I'm not sure I fully understand the logic of the *toolsWindow* variable, so it's possible that my fix is incorrect, even if it fixes the problem I observed. Let me know what you think!

NB: along the way, I removed the code that adds reload shortcuts to the DevTools window, since that window registers and handles its own reload shortcuts.
